### PR TITLE
Expose STA MAC address along with softAP one

### DIFF
--- a/esp/src/SckESP.cpp
+++ b/esp/src/SckESP.cpp
@@ -32,6 +32,7 @@ void SckESP::setup()
 
     // Create hostname
     macAddr = WiFi.softAPmacAddress();
+    staMacAddr = WiFi.macAddress();
     String tailMacAddr = macAddr.substring(macAddr.length() - 5);
     tailMacAddr.replace(":", "");
     strncpy(hostname, "Smartcitizen", 20);
@@ -444,7 +445,8 @@ bool SckESP::sendStartInfo()
 {
 	StaticJsonDocument<NETBUFF_SIZE> jsonBuffer;
 	JsonObject jsonSend = jsonBuffer.to<JsonObject>();
-	jsonSend["mac"] = macAddr;
+	jsonSend["mac"] = macAddr; // SoftAP MAC Address
+	jsonSend["stamac"] = staMacAddr; // STA-MAC Address
 	jsonSend["ver"] = ESPversion;
 	jsonSend["bd"] = ESPbuildDate;
 
@@ -731,9 +733,13 @@ void SckESP::webStatus(AsyncWebServerRequest *request)
     // Hostname
     json += "{\"hostname\":\"" + String(hostname) + "\",";
 
-    // MAC address
+    // MAC address (softAP)
     String tmac = WiFi.softAPmacAddress();
     json += "\"mac\":\"" + tmac + "\",";
+
+    // MAC address (STA)
+    String tmacsta = WiFi.macAddress();
+    json += "\"mac_sta\":\"" + tmacsta + "\",";
 
     // ESP firmware version
     json += "\"ESPversion\":\"" + ESPversion.substring(0, ESPversion.indexOf("-")) + "\",";

--- a/esp/src/SckESP.h
+++ b/esp/src/SckESP.h
@@ -78,7 +78,8 @@ class SckESP
 
         // Wifi related
         char hostname[20];
-        String macAddr;
+        String macAddr; // SoftAP MAC Address
+        String staMacAddr; // STA-MAC Address
         String ipAddr;
         int currentWIFIStatus;
         void tryConnection();

--- a/lib/Shared/Config.h
+++ b/lib/Shared/Config.h
@@ -49,7 +49,7 @@ struct Credentials { bool set=false; char ssid[64]="null"; char pass[64]="null";
 struct Token { bool set=false; char token[7]="null"; };
 struct Mqtt { char server[64]="mqtt.smartcitizen.me"; uint16_t port=1883; };
 struct Ntp { char server[64]="ntp.smartcitizen.me"; uint16_t port=80; };
-struct MAC { bool valid=false; char address[18]="not synced"; };
+struct MAC { bool valid=false; char address[18]="not synced"; char staaddress[18]="not synced";};
 struct BattConf { int16_t chargeCurrent=768; uint32_t battCapacity=2000; };
 struct Extra { bool ccsBaselineValid=false; uint16_t ccsBaseline; bool pmPowerSave=true; uint32_t pmWarmUpPeriod=15; }; 			// Here we save variables that don't have an specific place
 struct Offline { uint32_t retry = default_publish_interval * 5; int8_t start=-1; int8_t end=-1; };

--- a/sam/src/Commands.cpp
+++ b/sam/src/Commands.cpp
@@ -51,7 +51,7 @@ void getVersion_com(SckBase* base, String parameters)
     base->getUniqueID();
     sprintf(base->outBuff, "Hardware Version: %s\r\nSAM Hardware ID: %s\r\nSAM version: %s\r\nSAM build date: %s", base->hardwareVer.c_str(), base->uniqueID_str, base->SAMversion.c_str(), base->SAMbuildDate.c_str());
     base->sckOut();
-    sprintf(base->outBuff, "ESP MAC address: %s\r\nESP version: %s\r\nESP build date: %s", base->config.mac.address, base->ESPversion.c_str(), base->ESPbuildDate.c_str());
+    sprintf(base->outBuff, "ESP version: %s\r\nESP build date: %s", base->ESPversion.c_str(), base->ESPbuildDate.c_str());
     base->sckOut();
 }
 void resetCause_com(SckBase* base, String parameters)
@@ -1026,8 +1026,8 @@ void config_com(SckBase* base, String parameters)
     else sprintf(base->outBuff, "Token: not configured");
     base->sckOut();
 
-    sprintf(base->outBuff, "Mac address:  %s", base->config.mac.address);
-    base->sckOut();
+    // sprintf(base->outBuff, "Mac address:  %s", base->config.mac.address);
+    // base->sckOut();
 
     sprintf(base->outBuff, "Sanity reset (every 24 hours) is: %s", base->config.sanityResetFlag ? "on" : "off");
     base->sckOut();

--- a/sam/src/SckBase.cpp
+++ b/sam/src/SckBase.cpp
@@ -1048,7 +1048,7 @@ void SckBase::ESPbusUpdate()
 
 				ipAddress = json["ip"].as<String>();
 
-				sprintf(outBuff, "\r\nHostname: %s\r\nIP address: %s\r\nMAC address: %s", hostname, ipAddress.c_str(), config.mac.address);
+				sprintf(outBuff, "\r\nHostname: %s\r\nIP address: %s\r\nAP MAC address: %s\r\nSTA MAC address: %s", hostname, ipAddress.c_str(), config.mac.address, config.mac.staaddress);
 				sckOut();
 				sprintf(outBuff, "ESP version: %s\r\nESP build date: %s", ESPversion.c_str(), ESPbuildDate.c_str());
 				sckOut();
@@ -1151,13 +1151,17 @@ void SckBase::ESPbusUpdate()
 			JsonObject json = jsonBuffer.as<JsonObject>();
 
 			String macAddress = json["mac"].as<String>();
+			String staMacAddress = json["stamac"].as<String>();
 			ESPversion = json["ver"].as<String>();
 			ESPbuildDate = json["bd"].as<String>();
 
 			// Udate mac address and hostname if we haven't yet
 			if (!config.mac.valid) {
 				sckOut("Updated MAC address");
+				sckOut("AP MAC address");
 				sprintf(config.mac.address, "%s", macAddress.c_str());
+				sckOut("STA MAC address");
+				sprintf(config.mac.staaddress, "%s", staMacAddress.c_str());
 				config.mac.valid = true;
 				saveConfig();
 				snprintf(hostname, sizeof(hostname), "%s", "Smartcitizen");


### PR DESCRIPTION
This PR exposes the MAC address for the ESP for both the Station and the SoftAP. When connecting to a network, the MAC addresses are different for both modes, and MAC address filtering on certain networks doesn't work otherwise.

This also updates the commands for `netinfo` (now includes both MAC addresses), `version` and `config`, which now do not return the MAC address to avoid repeating the same information in multiple places. It also updates the ESP information AP to make the MAC address available to users in the info tab via their phone.