### PR TITLE
Bugfix/atlas sleep

### DIFF
--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -1690,14 +1690,13 @@ bool Atlas::sendCommand(char* command)
         auxWire.requestFrom(deviceAddress, 1, true);
         uint8_t confirmed = auxWire.read();
         auxWire.endTransmission();
-        delay(shortWait);
 
         if (confirmed == 1) {
             lastCommandSent = millis();
             return true;
         }
 
-        // delay(300);
+        delay(shortWait);
     }
     return false;
 }

--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -1682,13 +1682,14 @@ bool Atlas::sendCommand(char* command)
         auxWire.requestFrom(deviceAddress, 1, true);
         uint8_t confirmed = auxWire.read();
         auxWire.endTransmission();
+        delay(shortWait);
 
         if (confirmed == 1) {
             lastCommandSent = millis();
             return true;
         }
 
-        delay(300);
+        // delay(300);
     }
     return false;
 }

--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -1577,7 +1577,13 @@ bool Atlas::getBusyState()
     if (millis() - lastUpdate < 2) return true;
     switch (state) {
 
-        case REST: {
+        case SLEEP: {
+
+            if (millis() - lastCommandSent >= shortWait) {
+                if (sendCommand((char*)"r")) state = REST;
+            }
+
+        } case REST: {
 
             // ORP doesn't need temp compensation so we jump directly to ask reading
             if (ORP) {
@@ -1668,7 +1674,9 @@ void Atlas::goToSleep()
     auxWire.beginTransmission(deviceAddress);
     auxWire.write("Sleep");
     auxWire.endTransmission();
+    state = SLEEP;
 }
+
 bool Atlas::sendCommand(char* command)
 {
 

--- a/sam/src/SckAux.h
+++ b/sam/src/SckAux.h
@@ -360,6 +360,7 @@ class Atlas
         uint32_t lastUpdate = 0;
         enum State {
             REST,
+            SLEEP,
             TEMP_COMP_SENT,
             ASKED_READING,
         };


### PR DESCRIPTION
Fixes the issue in which atlas readings may not be correct when we return from a `sleep` command. It adds a `sleep` mode in the atlas drivers implementation state machine to wake up with a reading and avoid using it as part as the logged data.
It also increases a delay so that some slow processing drivers don't get stuck.