### PR TITLE
Create interface for SHT31 custom calibration

### DIFF
--- a/lib/Sensors/Sensors.h
+++ b/lib/Sensors/Sensors.h
@@ -536,8 +536,8 @@ class AllSensors
 #endif
 
 #ifdef WITH_EXT_TEMP
-            OneSensor { BOARD_AUX,      0,      SENSOR_SHT31_TEMP,              "EXT_TEMP",         "Ext Temperature",                      79,     true,       1,  "C"         },
-            OneSensor { BOARD_AUX,      0,      SENSOR_SHT31_HUM,               "EXT_HUM",          "Ext Humidity",                         80,     true,       1,  "%"         },
+            OneSensor { BOARD_AUX,      0,      SENSOR_SHT31_TEMP,              "EXT_TEMP_SHT31",   "Ext SHT31 Temperature",                79,     true,       1,  "C"         },
+            OneSensor { BOARD_AUX,      0,      SENSOR_SHT31_HUM,               "EXT_HUM_SHT31",    "Ext SHT31 Humidity",                   80,     true,       1,  "%"         },
             OneSensor { BOARD_AUX,      0,      SENSOR_SHT35_TEMP,              "EXT_TEMP_SHT35",   "Ext SHT35 Temperature",                224,    true,       1,  "C"         },
             OneSensor { BOARD_AUX,      0,      SENSOR_SHT35_HUM,               "EXT_HUM_SHT35",    "Ext SHT35 Humidity",                   225,    true,       1,  "%"         },
 #endif

--- a/lib/Sensors/Sensors.h
+++ b/lib/Sensors/Sensors.h
@@ -11,6 +11,8 @@
 #define WITH_SFA30
 #define WITH_GPS
 #define WITH_EXT_TEMP
+#define URBAN_T_OFFSET -1.3
+#define URBAN_RH_OFFSET 5
 #endif
 
 #ifdef SCK22_AIR
@@ -23,6 +25,9 @@
 #define WITH_SFA30
 #define WITH_GPS
 #define WITH_EXT_TEMP
+
+#define URBAN_T_OFFSET -1.0
+#define URBAN_RH_OFFSET 3.5
 #endif
 
 #ifdef SCK23_AIR
@@ -35,6 +40,9 @@
 #define WITH_SFA30
 #define WITH_GPS
 #define WITH_EXT_TEMP
+
+#define URBAN_T_OFFSET -1.0
+#define URBAN_RH_OFFSET 3.5
 #endif
 
 #ifdef SCK_WATER
@@ -255,7 +263,7 @@ enum SensorType
     SENSOR_SHT35_HUM,
 #endif
 
-#ifdef WTIH_RANGE
+#ifdef WITH_RANGE
     SENSOR_RANGE_LIGHT,
     SENSOR_RANGE_DISTANCE,
 #endif
@@ -534,7 +542,7 @@ class AllSensors
             OneSensor { BOARD_AUX,      0,      SENSOR_SHT35_HUM,               "EXT_HUM_SHT35",    "Ext SHT35 Humidity",                   225,    true,       1,  "%"         },
 #endif
 
-#ifdef WTIH_RANGE
+#ifdef WITH_RANGE
             OneSensor { BOARD_AUX,      100,    SENSOR_RANGE_LIGHT,             "EXT_RANGE_LIGHT",  "Ext Range Light",                      0,      true,       1,  "lux"       },
             OneSensor { BOARD_AUX,      100,    SENSOR_RANGE_DISTANCE,          "EXT_RANGE_DIST",   "Ext Range Distance",                   98,     true,       1,  "mm"        },
 #endif

--- a/lib/Shared/Config.h
+++ b/lib/Shared/Config.h
@@ -51,7 +51,26 @@ struct Mqtt { char server[64]="mqtt.smartcitizen.me"; uint16_t port=1883; };
 struct Ntp { char server[64]="ntp.smartcitizen.me"; uint16_t port=80; };
 struct MAC { bool valid=false; char address[18]="not synced"; char staaddress[18]="not synced";};
 struct BattConf { int16_t chargeCurrent=768; uint32_t battCapacity=2000; };
-struct Extra { bool ccsBaselineValid=false; uint16_t ccsBaseline; bool pmPowerSave=true; uint32_t pmWarmUpPeriod=15; }; 			// Here we save variables that don't have an specific place
+// Here we save variables that don't have an specific place
+struct Extra {
+	bool ccsBaselineValid=false;
+	uint16_t ccsBaseline;
+	bool pmPowerSave=true;
+	uint32_t pmWarmUpPeriod=15;
+#ifdef SCK21_AIR
+	float urbanTemperatureOffset=-1.3;
+	float urbanHumidityOffset=5;
+#endif
+#ifdef SCK22_AIR
+	float urbanTemperatureOffset=-1.0;
+	float urbanHumidityOffset=3.5;
+#endif
+#ifdef SCK23_AIR
+	float urbanTemperatureOffset=-1.0;
+	float urbanHumidityOffset=3.5;
+#endif
+};
+
 struct Offline { uint32_t retry = default_publish_interval * 5; int8_t start=-1; int8_t end=-1; };
 
 struct Configuration {

--- a/lib/Shared/Config.h
+++ b/lib/Shared/Config.h
@@ -57,18 +57,9 @@ struct Extra {
 	uint16_t ccsBaseline;
 	bool pmPowerSave=true;
 	uint32_t pmWarmUpPeriod=15;
-#ifdef SCK21_AIR
-	float urbanTemperatureOffset=-1.3;
-	float urbanHumidityOffset=5;
-#endif
-#ifdef SCK22_AIR
-	float urbanTemperatureOffset=-1.0;
-	float urbanHumidityOffset=3.5;
-#endif
-#ifdef SCK23_AIR
-	float urbanTemperatureOffset=-1.0;
-	float urbanHumidityOffset=3.5;
-#endif
+
+	float urbanTemperatureOffset=URBAN_T_OFFSET;
+	float urbanHumidityOffset=URBAN_RH_OFFSET;
 };
 
 struct Offline { uint32_t retry = default_publish_interval * 5; int8_t start=-1; int8_t end=-1; };

--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -790,11 +790,11 @@ String AuxBoards::control(SensorType wichSensor, String command)
 
                 String response;
                 if (command.length() == 0) {
-                    response += "Current humidity offset: " + String(sht31.humidityOffset) + " (degC)";
+                    response += "Current humidity offset: " + String(sht31.humidityOffset) + " (rh)";
                     return response;
                 } else if (command.startsWith("clear")) {
                     sht31.setDefaultHumidityOffset(false);
-                    response += "Set default offset: " + String(sht31.humidityOffset) + " (degC)";
+                    response += "Set default offset: " + String(sht31.humidityOffset) + " (rh)";
                     data.rhtCalibration.extHumidityOffset = sht31.humidityOffset;
                     eepromAuxData.write(data);
                     return response;
@@ -824,11 +824,11 @@ String AuxBoards::control(SensorType wichSensor, String command)
 
                 String response;
                 if (command.length() == 0) {
-                    response += "Current humidity offset: " + String(sht35.humidityOffset) + " (degC)";
+                    response += "Current humidity offset: " + String(sht35.humidityOffset) + " (rh)";
                     return response;
                 } else if (command.startsWith("clear")) {
                     sht35.setDefaultHumidityOffset(false);
-                    response += "Set default offset: " + String(sht35.humidityOffset) + " (degC)";
+                    response += "Set default offset: " + String(sht35.humidityOffset) + " (rh)";
                     data.rhtCalibration.extHumidityOffset = sht35.humidityOffset;
                     eepromAuxData.write(data);
                     return response;

--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -800,7 +800,7 @@ String AuxBoards::control(SensorType wichSensor, String command)
                     return response;
                 }
 
-                uint8_t newCalOffset = command.toFloat();
+                float newCalOffset = command.toFloat();
 
                 if (newCalOffset) {
                     if (!sht31.setHumidityOffset(newCalOffset)) return F("Failed to set new humidity offset");
@@ -834,7 +834,7 @@ String AuxBoards::control(SensorType wichSensor, String command)
                     return response;
                 }
 
-                uint8_t newCalOffset = command.toFloat();
+                float newCalOffset = command.toFloat();
 
                 if (newCalOffset) {
                     if (!sht35.setHumidityOffset(newCalOffset)) return F("Failed to set new humidity offset");

--- a/sam/src/SckAux.h
+++ b/sam/src/SckAux.h
@@ -89,13 +89,18 @@ extern TwoWire auxWire;
 class SckBase;
 
 
-struct Calibration {
+struct MoistureCalibration {
     bool  moistureCalDataValid = false;
     int32_t dryPoint;
     int32_t wetPoint;
 };
 
-struct Config {
+struct TempCalibration {
+    float  extTemperatureOffset = 0;
+    float  extHumidityOffset = 0;
+};
+
+struct AtlasConfig {
     bool  pHEnableTComp = true;
     bool  DOEnableTComp = true;
     bool  ECEnableTComp = true;
@@ -103,8 +108,9 @@ struct Config {
 
 struct EepromAuxData {
     bool valid = false;
-    Calibration calibration;
-    Config config;
+    MoistureCalibration moistCalibration;
+    TempCalibration rhtCalibration;
+    AtlasConfig atlasConfig;
 };
 
 bool I2Cdetect(byte address);

--- a/sam/src/SckBase.cpp
+++ b/sam/src/SckBase.cpp
@@ -674,7 +674,9 @@ void SckBase::loadConfig()
 	hostname[16] = '\0';
 
 #ifdef WITH_URBAN
-
+	// PMS sensor warmUpperiod and powerSave config
+	urban.sck_sht31.temperatureOffset = config.extra.urbanTemperatureOffset;
+	urban.sck_sht31.humidityOffset = config.extra.urbanHumidityOffset;
 #ifdef WITH_CCS811
 	// CSS vocs sensor baseline loading
 	if (config.extra.ccsBaselineValid && I2Cdetect(&Wire, urban.sck_ccs811.address)) {
@@ -2039,90 +2041,6 @@ bool SckBase::getReading(OneSensor *wichSensor)
 
     // Sensor reading ERROR, save null value
     if (wichSensor->state == -1) wichSensor->reading == "null";
-
-#ifdef WITH_URBAN
-    // Temperature / Humidity temporary Correction
-    // TODO remove this when calibration routine is ready
-    if (wichSensor->type == SENSOR_TEMPERATURE) {
-        float aux_temp = wichSensor->reading.toFloat();
-
-        // TODO This needs major refactoring...
-        // Corrections are linear, with no slope correction, only offset
-        float net_usb_t_offset = 0;
-        float net_batt_t_offset = 0;
-        float sd_usb_t_offset = 0;
-        float sd_batt_t_offset = 0;
-
-#ifdef SCK21_AIR
-        net_usb_t_offset =  - 1.45; // DONE
-        sd_usb_t_offset = -1.6;  // TODO CHECK
-        net_batt_t_offset = -1.3;  // DONE
-        sd_batt_t_offset = -1.3; // TODO CHECK
-#endif
-
-#ifdef SCK22_AIR
-        net_usb_t_offset =  - 1.25; // DONE
-        sd_usb_t_offset = -1.3; // DONE
-        net_batt_t_offset = -1.05; // DONE
-        sd_batt_t_offset = -1.0; // DONE
-#endif
-
-#ifdef SCK23_AIR // We assume offsets are the same between SCK22 and SCK23
-        net_usb_t_offset =  - 1.25; // DONE
-        sd_usb_t_offset = -1.3; // DONE
-        net_batt_t_offset = -1.05; // DONE
-        sd_batt_t_offset = -1.0; // DONE
-#endif
-
-        // Correct depending on battery/USB and network/sd card status
-        if (charger.onUSB) {
-            if (st.mode == MODE_NET) wichSensor->reading = String(aux_temp + net_usb_t_offset);
-            else wichSensor->reading = String(aux_temp + sd_usb_t_offset);
-        } else {
-            if (st.mode == MODE_NET) wichSensor->reading = String(aux_temp + net_batt_t_offset);
-            else wichSensor->reading = String(aux_temp + sd_batt_t_offset);
-        }
-
-    } else if(wichSensor->type == SENSOR_HUMIDITY) {
-
-        float aux_hum = wichSensor->reading.toFloat();
-        // Corrections are linear, with no slope correction, only offset
-        float net_usb_h_offset = 0;
-        float net_batt_h_offset = 0;
-        float sd_usb_h_offset = 0;
-        float sd_batt_h_offset = 0;
-
-#ifdef SCK21_AIR
-        net_usb_h_offset = 5; // DONE
-        sd_usb_h_offset = 5; // TODO CHECK
-        net_batt_h_offset = 5; // DONE
-        sd_batt_h_offset = 5; // TODO CHECK
-#endif
-
-#ifdef SCK22_AIR
-        net_usb_h_offset = 3.8; // DONE
-        sd_usb_h_offset = 4; // DONE
-        net_batt_h_offset = 3.6; // DONE
-        sd_batt_h_offset = 3.4; // DONE
-#endif
-
-#ifdef SCK23_AIR // We assume offsets are the same between SCK22 and SCK23
-        net_usb_h_offset = 3.8; // DONE
-        sd_usb_h_offset = 4; // DONE
-        net_batt_h_offset = 3.6; // DONE
-        sd_batt_h_offset = 3.4; // DONE
-#endif
-
-        // Correct depending on battery/USB and network/sd card status
-        if (charger.onUSB) {
-            if (st.mode == MODE_NET) wichSensor->reading = String(aux_hum  + net_usb_h_offset);
-            else wichSensor->reading = String(aux_hum + sd_usb_h_offset);
-        } else {
-            if (st.mode == MODE_NET) wichSensor->reading = String(aux_hum + net_batt_h_offset);
-            else wichSensor->reading = String(aux_hum + sd_batt_h_offset);
-        }
-    }
-#endif
 
     return true;
 }

--- a/sam/src/SckUrban.cpp
+++ b/sam/src/SckUrban.cpp
@@ -352,7 +352,7 @@ bool SckUrban::control(SckBase *base, SensorType wichSensor, String command)
                         return "\r\n";
                     }
 
-                    uint8_t newCalOffset = command.toFloat();
+                    float newCalOffset = command.toFloat();
 
                     if (newCalOffset) {
 

--- a/sam/src/SckUrban.h
+++ b/sam/src/SckUrban.h
@@ -124,6 +124,7 @@ class Sck_SHT31
         float temperatureOffset;
         float humidityOffset;
 
+        // Default calibration defined in Sensors.h or 0, for non-urban board sensors
         void setDefaultTemperatureOffset(bool urban=true) {temperatureOffset = (urban) ? URBAN_T_OFFSET : 0.0;}
         void setDefaultHumidityOffset(bool urban=true) {humidityOffset = (urban) ? URBAN_RH_OFFSET: 0.0;}
 

--- a/sam/src/SckUrban.h
+++ b/sam/src/SckUrban.h
@@ -107,6 +107,7 @@ class Sck_SHT31
         bool update();
         bool sendComm(uint16_t comm);
         uint8_t crc8(const uint8_t *data, int len);
+
     public:
         uint8_t address;
         // Conntructor
@@ -118,10 +119,13 @@ class Sck_SHT31
         bool stop();
         bool getReading();
         bool getReading(SckBase *base);
-        bool setTemperatureOffset(SckBase *base, float calOffset);
-        bool setHumidityOffset(SckBase *base, float calOffset);
+        bool setTemperatureOffset(float calOffset);
+        bool setHumidityOffset(float calOffset);
         float temperatureOffset;
         float humidityOffset;
+
+        void setDefaultTemperatureOffset(bool urban=true) {temperatureOffset = (urban) ? URBAN_T_OFFSET : 0.0;}
+        void setDefaultHumidityOffset(bool urban=true) {humidityOffset = (urban) ? URBAN_RH_OFFSET: 0.0;}
 
 #ifdef SCK21_AIR
         float chTemperatureOffset=-0.2;

--- a/sam/src/SckUrban.h
+++ b/sam/src/SckUrban.h
@@ -117,6 +117,24 @@ class Sck_SHT31
         bool start();
         bool stop();
         bool getReading();
+        bool getReading(SckBase *base);
+        bool setTemperatureOffset(SckBase *base, float calOffset);
+        bool setHumidityOffset(SckBase *base, float calOffset);
+        float temperatureOffset;
+        float humidityOffset;
+
+#ifdef SCK21_AIR
+        float chTemperatureOffset=-0.2;
+        float chHumidityOffset=0;
+#endif
+#ifdef SCK22_AIR
+        float chTemperatureOffset=-0.2;
+        float chHumidityOffset=0.5;
+#endif
+#ifdef SCK23_AIR
+        float chTemperatureOffset=-0.25;
+        float chHumidityOffset=0.5;
+#endif
     };
 
 // Noise


### PR DESCRIPTION
This adds an interface to calibrate temperature and humidity sensor offsets:

```
control temp cal
```

```
control hum cal
```

This will offer an interface for people to add an offset. This offset will be added to predefined ones, already tested on each hardware version, but that may require tweaks based on the enclosure, deployment conditions, etc.

