### PR TITLE
Fix shell parameter parsing

### DIFF
--- a/lib/Sensors/Sensors.cpp
+++ b/lib/Sensors/Sensors.cpp
@@ -42,7 +42,8 @@ uint8_t AllSensors::countMatchedWords(SensorType whichSensor, const char* input)
     char* rest = NULL;
     pch = strtok_r(inputLow," ", &rest);
     while (pch != NULL) {
-        if (strstr(titleCompare, pch) != NULL) matched++;
+        if (strstr(titleCompare, pch) == NULL) break;
+        matched++;
         pch = strtok_r(NULL, " ", &rest);
     }
 


### PR DESCRIPTION
This fixes issue #79.
It doesn't make sense to parse more tokens if the current one fails.
The old code matched two words in input "sen5x debug 1" for title "sen5x pm 1.0". It should had stopped at "debug" but went on to "1" and matched that in token "1.0".
TODO: Word in input should match a complete word in title and not just a substring. Not sure what the desired functionality is.