### PR TITLE
fix(flash): correct logic bugs, add corruption guards, and strengthen flash test

### DIFF
--- a/sam/src/SckList.cpp
+++ b/sam/src/SckList.cpp
@@ -1118,18 +1118,80 @@ uint32_t SckList::getFlashCapacity()
 }
 bool SckList::testFlash()
 {
-    String writeSRT = "testing the flash!";
+    // Use the last sector before the reserved area as a scratch sector so that
+    // the test never touches sector 0 (which may hold the current write cursor)
+    // or any sector that could contain live unpublished readings.
+    const uint16_t TEST_SECTOR = SCKLIST_SECTOR_NUM - 1;
+    const uint32_t BASE = _getSectAddr(TEST_SECTOR);
 
-    // Inside first sector
-    uint32_t fAddress = 1000;
-    flash.writeStr(fAddress, writeSRT);
+    SerialUSB.print("F: testFlash using sector ");
+    SerialUSB.println(TEST_SECTOR);
 
-    String readSTR;
-    flash.readStr(fAddress, readSTR);
+    // ── 1. Erase the scratch sector ────────────────────────────────────────
+    flash.eraseSector(BASE);
 
-    // Erase first sector to leave it clean
-    flash.eraseSector(_getSectAddr(0));
+    // Verify erase leaves 0xFF in the first few bytes
+    for (uint8_t i = 0; i < 8; i++) {
+        if (flash.readByte(BASE + i) != 0xFF) {
+            SerialUSB.println("F: testFlash FAIL — sector not blank after erase");
+            return false;
+        }
+    }
 
-    if (!readSTR.equals(writeSRT)) return false;
+    // ── 2. Byte write / read-back ───────────────────────────────────────────
+    const uint8_t BYTE_PATTERN = 0xA5;
+    flash.writeByte(BASE, BYTE_PATTERN);
+    if (flash.readByte(BASE) != BYTE_PATTERN) {
+        SerialUSB.println("F: testFlash FAIL — byte write/read mismatch");
+        flash.eraseSector(BASE);
+        return false;
+    }
+
+    // ── 3. readWord — the critical primitive used by _getGrpAddr / _getSectFreeSpace ──
+    // Write two known bytes and verify readWord returns them little-endian
+    flash.eraseSector(BASE);
+    flash.writeByte(BASE,     0x34);
+    flash.writeByte(BASE + 1, 0x12);
+    uint16_t word = flash.readWord(BASE);
+    if (word != 0x1234) {
+        SerialUSB.print("F: testFlash FAIL — readWord returned 0x");
+        SerialUSB.println(word, HEX);
+        flash.eraseSector(BASE);
+        return false;
+    }
+
+    // ── 4. readULong — used for timestamp reads ────────────────────────────
+    flash.eraseSector(BASE);
+    flash.writeByte(BASE,     0x78);
+    flash.writeByte(BASE + 1, 0x56);
+    flash.writeByte(BASE + 2, 0x34);
+    flash.writeByte(BASE + 3, 0x12);
+    uint32_t ulong = flash.readULong(BASE);
+    if (ulong != 0x12345678UL) {
+        SerialUSB.print("F: testFlash FAIL — readULong returned 0x");
+        SerialUSB.println(ulong, HEX);
+        flash.eraseSector(BASE);
+        return false;
+    }
+
+    // ── 5. Sequential write across sector boundary ─────────────────────────
+    // Write a 19-byte string near the end of the sector to make sure multi-byte
+    // operations don't silently truncate at the boundary.
+    flash.eraseSector(BASE);
+    const char* MSG = "boundary-test-msg";   // 17 chars + null = 18 bytes
+    uint32_t nearEnd = BASE + SECTOR_SIZE - 20;
+    flash.writeStr(nearEnd, String(MSG));
+    String readBack;
+    flash.readStr(nearEnd, readBack);
+    if (!readBack.equals(MSG)) {
+        SerialUSB.println("F: testFlash FAIL — near-boundary string write/read mismatch");
+        flash.eraseSector(BASE);
+        return false;
+    }
+
+    // ── 6. Clean up ────────────────────────────────────────────────────────
+    flash.eraseSector(BASE);
+
+    SerialUSB.println("F: testFlash PASS");
     return true;
 }

--- a/sam/src/SckList.cpp
+++ b/sam/src/SckList.cpp
@@ -79,6 +79,8 @@ bool SckList::_getGrpAddr(GroupIndex* wichGroup)
             return true;
         }
         uint16_t groupSize = flash.readWord(address);
+        if (groupSize == 0xFFFF) break;  // end of written data
+        if (groupSize == 0)      return false;  // corrupt: zero size would spin forever
 
         address += groupSize;
         groupCount++;
@@ -142,7 +144,9 @@ uint8_t SckList::_countReadings(GroupIndex wichGroup)
     uint8_t readingCounter = 0;
 
     while (readingAddr < finalGrpAddr) {
-        readingAddr += flash.readByte(readingAddr);
+        uint8_t readSize = flash.readByte(readingAddr);
+        if (readSize == 0) break;  // corrupt: zero size would spin forever
+        readingAddr += readSize;
         readingCounter++;
     }
 

--- a/sam/src/SckList.cpp
+++ b/sam/src/SckList.cpp
@@ -247,8 +247,10 @@ int8_t SckList::_closeSector(uint16_t wichSector)
     }
 
     // If no readings left, mark sector as published (_setSectPublished() will check if all readings are published)
-    _setSectPublished(_currSector - 1, PUB_NET);
-    _setSectPublished(_currSector - 1, PUB_SD);
+    // Use the wichSector parameter (the sector we just closed) rather than (_currSector - 1): when _currSector
+    // wraps from SCKLIST_SECTOR_NUM-1 to 0 the subtraction underflows to 0xFFFF as uint16_t.
+    _setSectPublished(wichSector, PUB_NET);
+    _setSectPublished(wichSector, PUB_SD);
 
     return 1;
 }
@@ -727,8 +729,11 @@ SckList::GroupIndex SckList::saveGroup()
                 enabledSensors++;
             }
         }
-        if (enabledSensors == 0) return {-1,-1,0};
     }
+    // Guard placed after iterating ALL sensors. The previous position was inside the for-loop body,
+    // causing an immediate early-return when sensor index 0 happened to be disabled or produce a
+    // null reading, silently discarding every subsequent sensor in the list.
+    if (enabledSensors == 0) return {-1,-1,0};
     if (debug) base->sckOut("<-");
 
     // Save group size at the begining of the group

--- a/sam/src/SckList.cpp
+++ b/sam/src/SckList.cpp
@@ -535,7 +535,8 @@ bool SckList::_countSectGroups(uint16_t wichSector, SectorInfo* info)
 
         // Find out groupSize
         uint16_t groupSize = flash.readWord(address);
-        if (groupSize == 0xFFFF) break;     // If GroupSize is not yet written that means no valid group is present
+        if (groupSize == 0xFFFF) break;  // end of written data
+        if (groupSize == 0)      return false;  // corrupt: zero size would spin forever
 
         // Store group state
         // get NET flag
@@ -574,7 +575,8 @@ int16_t SckList::_countSectGroups(uint16_t wichSector, PubFlags wichFlag, byte p
 
         // Find out groupSize
         uint16_t groupSize = flash.readWord(address);
-        if (groupSize == 0xFFFF) break;     // If GroupSize is not yet written that means no valid group is present
+        if (groupSize == 0xFFFF) break;  // end of written data
+        if (groupSize == 0)      return -1;  // corrupt: zero size would spin forever
 
         // Check if group is NOT published
         byte byteFlags = flash.readByte(address + addPositionFlag);
@@ -718,6 +720,17 @@ SckList::GroupIndex SckList::saveGroup()
     byte finit = 0xFF;
     memcpy(&flashBuff[GROUP_NET], &finit, 1);
     memcpy(&flashBuff[GROUP_SD], &finit, 1);
+
+    // Reject groups with no valid timestamp. epoch 0 means the RTC has never been set (SAMD21
+    // RTCZero initialises to 0 on first power-on without a battery-backed RTC). Storing such
+    // groups creates permanently wrong entries on the API (year 2000 timestamps) that cannot
+    // be corrected retroactively. The existing timeSyncAfterBoot flag in SckBase already tracks
+    // whether the clock has been synchronised; this guard enforces the same constraint at the
+    // storage layer so it holds regardless of call site.
+    if (base->lastSensorUpdate == 0) {
+        if (debug) base->sckOut("F: Skipping group save — RTC not yet set (epoch 0)");
+        return {-1,-1,0};
+    }
 
     // Store timeStamp of current group
     memcpy(&flashBuff[GROUP_TIME], &base->lastSensorUpdate, 4);     // Write timeStamp (4 bytes)

--- a/sam/src/SckList.cpp
+++ b/sam/src/SckList.cpp
@@ -52,6 +52,31 @@ bool SckList::_flashFormat()
 }
 
 // Read/Write functions
+bool SckList::_write(uint32_t wichAddr, char value)
+{
+    // Validate the target address before writing:
+    // - inside the current sector we must stay at or before _addr
+    // - inside any other sector the sector must not be empty (erased)
+    uint16_t wichSector = wichAddr / SECTOR_SIZE;
+    bool outOfBounds = false;
+    if (wichSector == (uint16_t)_currSector) {
+        if (wichAddr > _addr) outOfBounds = true;
+    } else {
+        if (_getSectState(wichSector) == SECTOR_EMPTY) outOfBounds = true;
+    }
+    if (outOfBounds) {
+        sprintf(base->outBuff, "F: Boundary error writing on flash address %lu (sector %u)", wichAddr, wichSector);
+        base->sckOut();
+        return false;
+    }
+
+    if (!flash.writeByte(wichAddr, value)) {
+        sprintf(base->outBuff, "F: Hardware error writing on flash address %lu", wichAddr);
+        base->sckOut();
+        return false;
+    }
+    return true;
+}
 bool SckList::_append(char value)
 {
     if (!flash.writeByte(_addr, value)) {
@@ -108,7 +133,7 @@ int8_t SckList::_setGrpPublished(GroupIndex wichGroup, PubFlags wichFlag)
     if (_dataAvailableSect[wichFlag] == _currSector && wichGroup.group == _lastGroup.group) availableReadings[wichFlag] = false;
 
     // And write flags byte back
-    return flash.writeByte(flagsAddr, PUBLISHED);
+    return _write(flagsAddr, PUBLISHED);
 }
 int8_t SckList::_isGrpPublished(GroupIndex wichGroup, PubFlags wichFlag)
 {
@@ -220,7 +245,7 @@ int8_t SckList::_setSectPublished(uint16_t wichSector, PubFlags wichFlag)
     if (_countSectGroups(wichSector, wichFlag, NOT_PUBLISHED) > 0) return -1;
 
     // And write flags byte
-    if (!flash.writeByte(flagsAddr, PUBLISHED)) return -1;
+    if (!_write(flagsAddr, PUBLISHED)) return -1;
 
 
     if (debug) {
@@ -236,7 +261,7 @@ int8_t SckList::_setSectPublished(uint16_t wichSector, PubFlags wichFlag)
 int8_t SckList::_closeSector(uint16_t wichSector)
 {
     // Mark sector as full
-    flash.writeByte(_getSectAddr(wichSector), SECTOR_USED);
+    _write(_getSectAddr(wichSector), SECTOR_USED);
 
 
     // Erase next sector and start using it

--- a/sam/src/SckList.h
+++ b/sam/src/SckList.h
@@ -115,6 +115,7 @@ class SckList
         GroupIndex potencialNextGroup = {-1,-1,0};  // To store potencial next groups to be published in batch mode
         GroupIndex _lastGroup = {-1,-1,0};      // To store the last saved group
 
+        bool _write(uint32_t wichAddr, char value); // Bounds-checked single-byte write; validates address is within a written sector
         bool _append(char value);           // Appends a byte at the end of the list
 
         // Flash memory functions

--- a/sam/src/SckTest.cpp
+++ b/sam/src/SckTest.cpp
@@ -353,12 +353,16 @@ uint8_t SckTest::test_flash()
     }
 
     if (!testBase->readingsList.testFlash()) {
-        SerialUSB.println("ERROR writing/reading flash chip!!!");
+        SerialUSB.println("ERROR: flash erase/write/read verification failed!");
         error = 1;
     }
 
-    test_report.tests[TEST_FLASH] = 1;
-    SerialUSB.println("Flash memory test finished OK");
+    // Only mark the test as passed when there are no errors.
+    // Previously TEST_FLASH was set to 1 unconditionally, masking failures.
+    if (error == 0) {
+        test_report.tests[TEST_FLASH] = 1;
+        SerialUSB.println("Flash memory test finished OK");
+    }
     title = true;
     return error;
 }


### PR DESCRIPTION
## Summary

Five focused commits targeting the flash storage layer (`SckList.cpp`) and the manufacturing test harness (`SckTest.cpp`). Ordered from most to least critical so each can be reviewed and bisected independently.

**Validation tooling** (serial test interface, `flash_test.py`, test protocol docs) lives in PR #113 and can be merged independently. Flash this branch under test using the `sck23_air_test` build environment from #113 to get the full validation workflow.

---

## Commits

### 1 — Always-wrong logic bugs (`5f4d259`)

**`_closeSector`: uint16_t underflow on sector wraparound**

`_setSectPublished(_currSector - 1, …)` was used after `_currSector` incremented and wrapped from `SCKLIST_SECTOR_NUM-1` to `0`. `0 - 1` as `uint16_t` produces `0xFFFF`. `_getSectAddr(0xFFFF)` returns `0xFFFFFFFF`; adding the flag offset overflows back to `0x00000000`, which passes the address sanity check. The sector just closed was never marked as published — the next scan could re-use it while it still held data. Fixed by using the `wichSector` parameter, which already holds the correct value.

**`saveGroup`: `enabledSensors == 0` guard inside the sensor for-loop**

The early-return was placed *inside* the `for (i = 0; i < SENSOR_COUNT; i++)` body. If sensor[0] was disabled or produced a null reading, the function returned `{-1,-1,0}` without checking any other sensor. Moved the check after the loop.

### 2 — Defensive corruption guards (`e1771c1`, `e23015c`)

Guards against infinite loops from zero-sized entries left by a power-loss mid-write:

| Function | Guard added |
|---|---|
| `_getGrpAddr` | `groupSize == 0` → `return false` |
| `_countReadings` | `readSize == 0` → `break` |
| `_countSectGroups` (SectorInfo overload) | `groupSize == 0` → `return false` |
| `_countSectGroups` (PubFlags overload) | `groupSize == 0` → `return -1` |

All four loops already guarded `groupSize == 0xFFFF` (end-of-data). `_getSectFreeSpace` already had the `== 0` guard; this brings the rest of the read path into parity.

### 3 — Epoch-0 timestamp guard (`e23015c`)

`saveGroup` now rejects `lastSensorUpdate == 0` before writing to flash. RTCZero on SAMD21 initialises to `0` on first power-on without a battery-backed RTC. Groups stored with epoch 0 produce **year-2000 timestamps** on the API that cannot be corrected retroactively.

### 4 — Bounds-checked `_write()` wrapper (`bfa3867`)

`_write(addr, value)` validates the target address before calling `flash.writeByte()`:
- Inside the current sector: address must be ≤ `_addr` (the write cursor)
- Any other sector: the sector must not be `SECTOR_EMPTY`

The three metadata write sites (`_setGrpPublished`, `_setSectPublished`, `_closeSector`) now use `_write()`.

### 5 — Expanded `testFlash()` and masked-result fix (`2d58642`)

- Previously wrote to sector 0, potentially destroying live readings. Now uses scratch sector `SCKLIST_SECTOR_NUM - 1`.
- Exercises `readByte`, `readWord`, `readULong`, `writeByte`, `writeStr`/`readStr`, and a near-boundary string write.
- `TEST_FLASH` is now only set to `1` when all steps pass.

---

## Test plan

**On-device manufacturing test (no extra tooling needed):**
```bash
cd sam && pio run -e sck23_air_test -t upload
# Open serial, press button when prompted
# Expected: F: testFlash PASS
```

**End-to-end validation with flash_test.py (requires PR #113 merged or firmware built from that branch):**
```bash
cd sam && pio run -e sck23_air_test -t upload
python flash_test.py test --sector 4 all --log-dir ./test-logs
```

The `zero-group` scenario directly exercises the corruption guards in commits `e1771c1` and `e23015c`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flash memory boundary validation and error reporting.
  * Prevented scanners from getting stuck on empty records.
  * Corrected sector publication during closure, including wraparound cases.
  * Improved group-saving validation for timestamps and sensor availability.
* **Tests**
  * Expanded flash diagnostics to cover erase, read, write, and boundary operations.
  * Flash tests now report verification failures accurately and only pass when all checks succeed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->