### PR TITLE
Improve make.py

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,7 @@ jobs:
 
     - name: Run Builds
       run: |
+        python make.py dump-env
         python make.py build sam --env all esp -v
 
     - name: Release

--- a/make.py
+++ b/make.py
@@ -58,7 +58,6 @@ if 'dump-env' in sys.argv:
     if other_actions:
         ERROR('dump-env cannot be combined with other actions: ' + ', '.join(other_actions)); sys.exit()
     kit = sck.sck(check_pio_sam=True, check_pio_esp=True, dump_env=True)
-    sys.exit()
 
 check_pio_sam = True
 check_pio_esp = True

--- a/make.py
+++ b/make.py
@@ -38,7 +38,7 @@ if '-h' in sys.argv or '--help' in sys.argv or '-help' in sys.argv or len(sys.ar
     print('\t-k: keep configuration')
     print('\t-p port: specify a port instead of scanning')
     print('\t-f: force flashing even if no SCK is found, (port must be specified)')
-    print('\t--no-pio-check: avoid checking platformio environments')
+    print('\t--no-sam-pio-check: avoid checking SAMD platformio environment')
     print('\nActions:\n\tboot: flash SAM bootloader (Extra hardware is needed)\n\tbuild: build firmware\n\tflash: upload compiled code\n\tdump-env: dump pio env to file')
     print('\nTargets:\n\tsam: SAMD21 chip\n\tesp: ESP8266 (WiFi) chip')
     print('\nTarget Options (only SAM):')
@@ -59,7 +59,7 @@ if 'dump-env' in sys.argv:
 
 check_pio_sam = True
 check_pio_esp = True
-if '--no-pio-check' in sys.argv:
+if '--no-sam-pio-check' in sys.argv:
     check_pio_sam = False
 
 kit = sck.sck(check_pio_sam=check_pio_sam, check_pio_esp=check_pio_esp)

--- a/make.py
+++ b/make.py
@@ -31,14 +31,15 @@ def blockPrint():
 def enablePrint():
     sys.stdout = sys.__stdout__
 
-if '-h' in sys.argv or '--help' in sys.argv or '-help' in sys.argv or len(sys.argv) < 2 or (not 'build' in sys.argv and not 'flash' in sys.argv and not 'boot' in sys.argv):
+if '-h' in sys.argv or '--help' in sys.argv or '-help' in sys.argv or len(sys.argv) < 2 or (not 'build' in sys.argv and not 'flash' in sys.argv and not 'boot' in sys.argv and not 'dump-env' in sys.argv):
     print('USAGE:\n\n\tpython make.py [options] action[s] target[s] [target-options]')
     print('\nOptions:')
     print('\t-v: verbose')
     print('\t-k: keep configuration')
     print('\t-p port: specify a port instead of scanning')
     print('\t-f: force flashing even if no SCK is found, (port must be specified)')
-    print('\nActions:\n\tboot: flash SAM bootloader (Extra hardware is needed)\n\tbuild: build firmware\n\tflash: upload compiled code')
+    print('\t--no-pio-check: avoid checking platformio environments')
+    print('\nActions:\n\tboot: flash SAM bootloader (Extra hardware is needed)\n\tbuild: build firmware\n\tflash: upload compiled code\n\tdump-env: dump pio env to file')
     print('\nTargets:\n\tsam: SAMD21 chip\n\tesp: ESP8266 (WiFi) chip')
     print('\nTarget Options (only SAM):')
     print('\t--env: Environment to build (all to build all)')
@@ -51,7 +52,17 @@ if '-v' in sys.argv:
     enablePrint()
 
 import sck
-kit = sck.sck(check_pio_sam='sam' in sys.argv, check_pio_esp='esp' in sys.argv)
+
+if 'dump-env' in sys.argv:
+    kit = sck.sck(check_pio_sam=True, check_pio_esp=True, dump_env=True)
+    sys.exit()
+
+check_pio_sam = True
+check_pio_esp = True
+if '--no-pio-check' in sys.argv:
+    check_pio_sam = False
+
+kit = sck.sck(check_pio_sam=check_pio_sam, check_pio_esp=check_pio_esp)
 
 if 'flash' in sys.argv:
     force = False
@@ -100,6 +111,8 @@ if 'boot' in sys.argv:
         ERROR('Failed building SCK bootloader!!!')
     os.chdir('../..')
 
+buildSAMOK = False
+buildESPOK = False
 if 'build' in sys.argv:
     if 'sam' in sys.argv:
         oneLine('Building SAM firmware... ')

--- a/make.py
+++ b/make.py
@@ -54,6 +54,9 @@ if '-v' in sys.argv:
 import sck
 
 if 'dump-env' in sys.argv:
+    other_actions = [a for a in ('build', 'flash', 'boot') if a in sys.argv]
+    if other_actions:
+        ERROR('dump-env cannot be combined with other actions: ' + ', '.join(other_actions)); sys.exit()
     kit = sck.sck(check_pio_sam=True, check_pio_esp=True, dump_env=True)
     sys.exit()
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `dump-env` CLI action to display the current environment.
  - Added the `--no-sam-pio-check` option to independently disable SAM PlatformIO checks.
- **Improvements**
  - Environment dumping now continues through normal initialization.
  - Incompatible combinations of `dump-env` with build, flash, or boot actions are rejected.
  - PlatformIO checks remain enabled by default, while ESP checks stay active.
  - Build and flash status reporting is initialized consistently.
  - Automated builds now collect environment details before building.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->