### PR TITLE
Avoid LED sending error if WiFi is connected

### DIFF
--- a/sam/src/SckBase.cpp
+++ b/sam/src/SckBase.cpp
@@ -317,7 +317,9 @@ void SckBase::reviewState()
         if (st.mode == MODE_NET) {
 
             // If We need conection now
-            if (st.helloPending || timeToPublish || !infoPublished) {
+            if (st.helloPending || timeToPublish || !infoPublished || wifiJustReconnected) {
+
+                wifiJustReconnected = false;
 
                 if (!st.tokenSet) {
 
@@ -1092,6 +1094,7 @@ void SckBase::ESPbusUpdate()
 
 			snprintf(outBuff, 240, "Connected to Wi-Fi!!- RSSI: %s", serESP.buff);
             sckOut();
+            wifiJustReconnected = true;
 			if (!timeSyncAfterBoot) {
 				if (ESPsend(ESPMES_GET_TIME, "")) sckOut("Asked new time sync to ESP...");
 			}

--- a/sam/src/SckBase.h
+++ b/sam/src/SckBase.h
@@ -131,6 +131,7 @@ class SckBase
 		bool publishInfo();
 		bool espInfoUpdated = false;
 		bool infoPublished = false;
+		bool wifiJustReconnected = false;
 
 		// Sd card
 		volatile bool sdInitPending = false;


### PR DESCRIPTION
This PR tries to fix an issue when the LED marks "ERROR" while it's actually connected to WiFi already. The cycle in which readings take place is the only one that clears the ERROR on the LED, but this tries to avoid that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the hello, device information, and publishing workflow after Wi‑Fi connectivity is re-established.
  * Wi‑Fi reconnection events are now handled reliably in network mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->