### PR TITLE
Attempt to print data on screen even if there is WiFi failure, while showing a banner

### DIFF
--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -1270,18 +1270,12 @@ void Groove_OLED::update(SckBase* base, bool force)
     // Info bar
     drawBar(base);
 
-    if (base->st.error == ERROR_NONE) {
+    // Setup mode screen, or rotate through sensor readings
+    if (base->st.onSetup) drawSetup(base);
+    else displayReading(base);
 
-        // Setup mode screen
-        if (base->st.onSetup) drawSetup(base);
-        else displayReading(base);
-
-    } else {
-
-        // Error popup
-        drawError(base->st.error);
-
-    }
+    // Error popup overlaid on top, so readings keep rotating even in error state
+    if (base->st.error != ERROR_NONE) drawError(base->st.error);
 
 }
 void Groove_OLED::drawBar(SckBase* base)
@@ -1350,8 +1344,6 @@ void Groove_OLED::drawBar(SckBase* base)
 }
 void Groove_OLED::drawError(errorType whichError)
 {
-    if (lastError == whichError) return;
-
     // Clear error buffer area
     uint8_t *buffStart = u8g2_oled.getBufferPtr();
     memset(&buffStart[1792], 0, 256);
@@ -1402,8 +1394,6 @@ void Groove_OLED::drawError(errorType whichError)
 
     // Print message
     u8g2_oled.drawStr(19, 125, errorMsg);
-
-    lastError = whichError;
 
     // Update display
     u8g2_oled.updateDisplayArea(0, 14, 16, 2);

--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -1270,9 +1270,14 @@ void Groove_OLED::update(SckBase* base, bool force)
     // Info bar
     drawBar(base);
 
+    // If an error just cleared, force a redraw now so that the error banner
+    // isn't left on screen until the next scheduled sensor rotation
+    bool errorJustCleared = (lastError != ERROR_NONE && base->st.error == ERROR_NONE);
+    lastError = base->st.error;
+
     // Setup mode screen, or rotate through sensor readings
     if (base->st.onSetup) drawSetup(base);
-    else displayReading(base);
+    else displayReading(base, errorJustCleared);
 
     // Error popup overlaid on top, so readings keep rotating even in error state
     if (base->st.error != ERROR_NONE) drawError(base->st.error);
@@ -1425,9 +1430,9 @@ void Groove_OLED::drawSetup(SckBase* base)
 
     u8g2_oled.updateDisplayArea(0, 2, 16, 14);
 }
-void Groove_OLED::displayReading(SckBase* base)
+void Groove_OLED::displayReading(SckBase* base, bool force)
 {
-    if (base->rtc.getEpoch() - showStartTime <= showTime) return;
+    if (!force && base->rtc.getEpoch() - showStartTime <= showTime) return;
 
     SensorType sensorToShow = SENSOR_COUNT;
     uint8_t cycles = 0;

--- a/sam/src/SckAux.h
+++ b/sam/src/SckAux.h
@@ -286,7 +286,7 @@ class Groove_OLED
         bool stop();
         void print(char *payload);
         void update(SckBase* base, bool force);
-        void displayReading(SckBase* base);
+        void displayReading(SckBase* base, bool force=false);
         void plot(String value, const char *title=NULL, const char *unit=NULL);
 
     private:
@@ -298,6 +298,7 @@ class Groove_OLED
 
         void drawBar(SckBase* base);
         void drawError(errorType whichError);
+        errorType lastError = ERROR_NONE;
         void drawSetup(SckBase* base);
 
         // Plot

--- a/sam/src/SckAux.h
+++ b/sam/src/SckAux.h
@@ -298,7 +298,6 @@ class Groove_OLED
 
         void drawBar(SckBase* base);
         void drawError(errorType whichError);
-        errorType lastError;
         void drawSetup(SckBase* base);
 
         // Plot


### PR DESCRIPTION
Addresses #120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Error messages now appear as overlays on top of the setup screen or live sensor readings.
  - Sensor readings remain visible while an error is active.
  - Active error notifications refresh consistently during screen updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->