### PR TITLE
Rename debug OLED flags

### DIFF
--- a/lib/Sensors/Sensors.h
+++ b/lib/Sensors/Sensors.h
@@ -65,7 +65,7 @@
 // #define WITH_PMS
 
 // Auxiliary Sensors (ALl this sensors use around 8kb)
-// #define WITH_SENSOR_GROVE_OLED  // Saves 2496 bytes
+// #define SCK_WITH_SENSOR_GROVE_OLED  // Saves 2496 bytes
 // #define WITH_GASES_BOARD        // Saves 756 bytes
 // #define WITH_GROVE_I2C_ADC      // Saves 244 bytes
 // #define WITH_INA219             // Saves 388 bytes
@@ -313,7 +313,7 @@ enum SensorType
 #endif
 
     // Actuators (This is temp)
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
     SENSOR_GROVE_OLED,
 #endif
 
@@ -591,7 +591,7 @@ class AllSensors
             OneSensor { BOARD_AUX,      100,    SENSOR_SFA30_FORMALDEHYDE,      "SFA30_HCHO",       "SFA30 Formaldehyde",                   212,    true,       1,  "ppb"                      },
 #endif
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
             // Later this will be moved to a Actuators.h file
             // Groove I2C Oled Display 96x96
             OneSensor { BOARD_AUX,      250,    SENSOR_GROVE_OLED,              "GR_OLED",          "Groove OLED",                          0,      true,       1,  "",          false         },

--- a/lib/Shared/Config.h
+++ b/lib/Shared/Config.h
@@ -42,7 +42,7 @@ enum errorType {
 	ERROR_ESP
 };
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 struct SensorConfig { bool enabled; uint8_t everyNint; bool oled_display=true; };
 struct Debug { bool sdcard=false; bool serial=false; bool oled=false; bool flash=false; bool speed=false; };
 #else

--- a/sam/src/Commands.cpp
+++ b/sam/src/Commands.cpp
@@ -159,7 +159,7 @@ void sensorConfig_com(SckBase* base, String parameters)
                 snprintf(base->outBuff, sizeof(base->outBuff), "%s -> every %i int (%lu sec)", base->sensors[thisType].title, base->sensors[thisType].everyNint, (base->sensors[thisType].everyNint * base->config.readInterval));
                 base->sckOut(PRIO_MED, false);
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
                 if (base->sensors[SENSOR_GROVE_OLED].enabled && base->config.sensors[thisType].oled_display)  base->sckOut(" - oled");
                 else base->sckOut(" ");
 #else
@@ -327,7 +327,7 @@ void sensorConfig_com(SckBase* base, String parameters)
             saveNeeded = true;
         }
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         if (parameters.indexOf("-oled") >=0) {
 
             base->config.sensors[sensorToChange].oled_display = !base->config.sensors[sensorToChange].oled_display;
@@ -521,7 +521,7 @@ void monitorSensor_com(SckBase* base, String parameters)
     for (uint8_t i=0; i<index; i++) {
         sprintf(base->outBuff, "%s%s", base->outBuff, base->sensors[sensorsToMonitor[i]].title);
         if (i < index - 1) snprintf(base->outBuff, sizeof(base->outBuff) - strlen(base->outBuff), "%s\t", base->outBuff);
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         if (oled && i==0) base->plot(base->sensors[sensorsToMonitor[i]].reading, base->sensors[sensorsToMonitor[i]].title, base->sensors[sensorsToMonitor[i]].unit);
 #endif
     }
@@ -601,7 +601,7 @@ void monitorSensor_com(SckBase* base, String parameters)
             if (wichSensor.state == 0) {
                 snprintf(base->outBuff, sizeof(base->outBuff) - strlen(base->outBuff), "%s\t%s", base->outBuff, wichSensor.reading.c_str());
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
                 if (theFirst && oled) {
                     base->plot(wichSensor.reading);
                     theFirst = false;
@@ -1098,7 +1098,7 @@ void debug_com(SckBase* base, String parameters)
 			base->sckOut();
 			saveNeeded = true;
 		}
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 		if (parameters.indexOf("-oled") >= 0) {
 			base->config.debug.oled = !base->config.debug.oled;
 			sprintf(base->outBuff, "Oled display debug: %s", base->config.debug.oled ? "true" : "false");
@@ -1132,7 +1132,7 @@ void debug_com(SckBase* base, String parameters)
 		sprintf(base->outBuff, "SD card debug: %s", base->config.debug.sdcard ? "true" : "false");
 		base->sckOut();
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 		sprintf(base->outBuff, "Oled display debug: %s", base->config.debug.oled ? "true" : "false");
 		base->sckOut();
 #endif

--- a/sam/src/Commands.h
+++ b/sam/src/Commands.h
@@ -104,7 +104,7 @@ public:
         OneCom {50,     COM_HELP,           "help",     "Duhhhh!!",                                                                                                                                                                                     help_com},
         OneCom {60,     COM_PINMUX,         "pinmux",   "Shows SAMD pin mapping status",                                                                                                                                                                pinmux_com},
         OneCom {90,     COM_FLASH,          "flash",    "Shows and manage flash memory state [no-param -> info] [-format (be careful)] [-dump sect-num (0-2040)] [-sector sect-num] [-recover sect-num/all net/sd]",                                   flash_com},
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         OneCom {80,     COM_LIST_SENSOR,    "sensor",   "Shows/sets sensor state or interval: sensor sensor-name [-enable or -disable] [-interval interval(seconds)] [-oled]",                                                                          sensorConfig_com},
         OneCom {90,     COM_MONITOR_SENSOR, "monitor",  "Continously read sensor: monitor [-sd] [-notime] [-noms] [-oled] [sensorName[,sensorNameN]]",                                                                                                  monitorSensor_com},
         OneCom {100,    COM_DEBUG,          "debug",    "Toggle debug messages: debug [-sdcard] [-oled] [-flash] [-speed] [-serial]",                                                                                                                   debug_com},

--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -9,7 +9,7 @@ GrooveI2C_ADC       grooveI2C_ADC;
 #ifdef WITH_INA219
 INA219              ina219;
 #endif
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 Groove_OLED         groove_OLED;
 #endif
 #ifdef WITH_DS18B20
@@ -209,7 +209,7 @@ bool AuxBoards::start(SckBase *base, SensorType whichSensor)
         case SENSOR_SFA30_HUMIDITY:
         case SENSOR_SFA30_FORMALDEHYDE:             return sck_sfa30.start(whichSensor);
 #endif
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         case SENSOR_GROVE_OLED:                     return groove_OLED.start();
 #endif
         default: break;
@@ -329,7 +329,7 @@ bool AuxBoards::stop(SensorType whichSensor)
         case SENSOR_SFA30_HUMIDITY:
         case SENSOR_SFA30_FORMALDEHYDE:             return sck_sfa30.start(whichSensor);
 #endif
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         case SENSOR_GROVE_OLED:                     return groove_OLED.stop();
 #endif
         default: break;
@@ -1072,7 +1072,7 @@ String AuxBoards::control(SensorType whichSensor, String command)
     }
     return "Unknown error on control command!!!";
 }
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 void AuxBoards::print(char *payload)
 {
     groove_OLED.print(payload);
@@ -1185,7 +1185,7 @@ float INA219::getReading(typeOfReading whichReading)
 }
 #endif
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 bool Groove_OLED::start()
 {
     if (!I2Cdetect(&auxWire, deviceAddress)) return false;

--- a/sam/src/SckAux.h
+++ b/sam/src/SckAux.h
@@ -20,7 +20,7 @@
 // Urban board library
 #include <SckUrban.h>
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 // Groove_OLED libs
 #include <U8g2lib.h>
 // Icons for screen
@@ -216,7 +216,7 @@ class AuxBoards
         void getReading(SckBase *base, OneSensor *whichSensor);
         bool getBusyState(SensorType whichSensor);
         String control(SensorType whichSensor, String command);
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         void print(char *payload);
         void updateDisplay(SckBase* base, bool force=false);
         void plot(String value, const char *title=NULL, const char *unit=NULL);
@@ -272,7 +272,7 @@ class INA219
     };
 #endif
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 // This implementation works with a 128x128 pixel Oled screen with SH1107 controler
 class Groove_OLED
     {

--- a/sam/src/SckBase.cpp
+++ b/sam/src/SckBase.cpp
@@ -123,7 +123,7 @@ void SckBase::setup()
                 enableSensor(wichSensor->type);
             } else {
                 wichSensor->enabled = false;
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
                 wichSensor->oled_display = false;
 #endif
             }
@@ -210,7 +210,7 @@ void SckBase::update()
         }
 #endif
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         // If we have a screen update it
         if (sensors[SENSOR_GROVE_OLED].enabled) auxBoards.updateDisplay(this);
 #endif
@@ -646,7 +646,7 @@ void SckBase::sckOut(PrioLevels priority, bool newLine)
         } else st.cardPresent = false;
     }
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
     // Debug output to oled display
     if (config.debug.oled) {
         if (sensors[SENSOR_GROVE_OLED].enabled) auxBoards.print(outBuff);
@@ -658,7 +658,7 @@ void SckBase::prompt()
     sprintf(outBuff, "%s", "SCK > ");
     sckOut(PRIO_MED, false);
 }
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 void SckBase::plot(String value, const char *title, const char *unit)
 {
     auxBoards.plot(value, title, unit);
@@ -730,7 +730,7 @@ void SckBase::saveConfig(bool defaults)
             SensorType wichSensorType = static_cast<SensorType>(i);
 
             config.sensors[wichSensorType].enabled = sensors[wichSensorType].defaultEnabled;
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
             config.sensors[wichSensorType].oled_display = sensors[wichSensorType].oled_display;
 #endif
             config.sensors[wichSensorType].everyNint = sensors[wichSensorType].defaultEveryNint;
@@ -1632,7 +1632,7 @@ void SckBase::updatePower()
 
                 sckOut("Emergency low battery!!", PRIO_ERROR);
                 st.error = ERROR_BATT;
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
                 auxBoards.updateDisplay(this, true);        // Force update of screen before going to sleep
 #endif
                 // Ignore last user event and go to sleep
@@ -1777,7 +1777,7 @@ void SckBase::sleepLoop()
         updateSensors();
         updatePower();
 
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         // If we have a screen update it
         if (sensors[SENSOR_GROVE_OLED].enabled) auxBoards.updateDisplay(this, true);
 #endif
@@ -1974,7 +1974,7 @@ bool SckBase::enableSensor(SensorType wichSensor)
         sprintf(outBuff, "Enabling %s", sensors[wichSensor].title);
         sckOut();
         sensors[wichSensor].enabled = true;
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
         sensors[wichSensor].oled_display = config.sensors[wichSensor].oled_display;  // Show detected sensors on oled display if config is true (default).
 #endif
         writeHeader = true;
@@ -1982,7 +1982,7 @@ bool SckBase::enableSensor(SensorType wichSensor)
     }
 
     sensors[wichSensor].enabled = false;
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
     sensors[wichSensor].oled_display = false;
 #endif
     // Avoid spamming with mesgs for every supported auxiliary sensor

--- a/sam/src/SckBase.h
+++ b/sam/src/SckBase.h
@@ -250,7 +250,7 @@ class SckBase
 		void sckOut(const char *strOut, PrioLevels priority=PRIO_MED, bool newLine=true);	// Accepts constant string
 		void sckOut(PrioLevels priority=PRIO_MED, bool newLine=true);
 		void prompt();
-#ifdef WITH_SENSOR_GROVE_OLED
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
 		void plot(String value, const char *title=NULL, const char *unit=NULL);
 #endif
 


### PR DESCRIPTION
Simple PR to rename OLED flags consistently with other debug flags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the compile-time configuration name for Grove OLED sensor support.
  - Grove OLED functionality is now enabled through the updated configuration setting across sensor setup, monitoring, debugging, display, and power-management features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->