### PR TITLE
Add reclock calls for aux wire and oled compatibility

### DIFF
--- a/sam/src/SckAux.cpp
+++ b/sam/src/SckAux.cpp
@@ -1235,13 +1235,14 @@ bool Groove_OLED::start()
 {
     if (!I2Cdetect(&auxWire, deviceAddress)) return false;
 
-    u8g2_oled.setBusClock(1000000);     // 1000000 -> 68 ms for a full buffer redraw
+    u8g2_oled.setBusClock(SCK_AUX_WIRE_OLED_CLOCK);     // 1000000 -> 68 ms for a full buffer redraw
     u8g2_oled.begin();
     u8g2_oled.drawXBM( 16, 16, 96, 96, scLogo);
     u8g2_oled.sendBuffer();
     currentLine = 1;
     delay(1000);
     u8g2_oled.clearDisplay();
+    auxWire.setClock(SCK_AUX_WIRE_STD_CLOCK);     // Restore bus speed for GPS/sensors sharing auxWire
 
     return true;;
 }
@@ -1277,6 +1278,7 @@ void Groove_OLED::print(char *payload)
     }
 
     u8g2_oled.sendBuffer();
+    auxWire.setClock(SCK_AUX_WIRE_STD_CLOCK);     // Restore bus speed for GPS/sensors sharing auxWire
 }
 void Groove_OLED::printLine(char *payload, uint8_t size)
 {
@@ -1327,6 +1329,7 @@ void Groove_OLED::update(SckBase* base, bool force)
     // Error popup overlaid on top, so readings keep rotating even in error state
     if (base->st.error != ERROR_NONE) drawError(base->st.error);
 
+    auxWire.setClock(SCK_AUX_WIRE_STD_CLOCK);     // Restore bus speed for GPS/sensors sharing auxWire
 }
 void Groove_OLED::drawBar(SckBase* base)
 {
@@ -1632,6 +1635,7 @@ void Groove_OLED::plot(String value, const char *title, const char *unit)
     u8g2_oled.drawHLine(118, 127, 10);
 
     u8g2_oled.sendBuffer();
+    auxWire.setClock(SCK_AUX_WIRE_STD_CLOCK);     // Restore bus speed for GPS/sensors sharing auxWire
 }
 void Groove_OLED::remap(float newMaxY)
 {

--- a/sam/src/SckAux.h
+++ b/sam/src/SckAux.h
@@ -91,6 +91,12 @@
 
 extern TwoWire auxWire;
 
+// Define speeds for AUX_WIRE and OLED_CLOCK to restore i2c
+#define SCK_AUX_WIRE_STD_CLOCK 100000
+#ifdef SCK_WITH_SENSOR_GROVE_OLED
+#define SCK_AUX_WIRE_OLED_CLOCK 1000000
+#endif
+
 class SckBase;
 
 

--- a/sam/src/SckBase.cpp
+++ b/sam/src/SckBase.cpp
@@ -99,6 +99,7 @@ void SckBase::setup()
     pinPeripheral(pinAUX_WIRE_SDA, PIO_SERCOM);
     pinPeripheral(pinAUX_WIRE_SCL, PIO_SERCOM);
     auxWire.begin();
+    auxWire.setClock(SCK_AUX_WIRE_STD_CLOCK);       // Standard/fast mode clock shared by GPS and sensors on this bus
     delay(3000);                // Give some time for external boards to boot
 
 


### PR DESCRIPTION
Fixes #96 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved communication reliability between the OLED display and other auxiliary I²C devices.
  * Standardized auxiliary bus speeds for GPS, sensors, and display operations to reduce device communication conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->